### PR TITLE
Remove permission group no longer used thus fixing warning

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -29,7 +29,6 @@
 
     <!-- Allows to queue downloads without a notification shown while the download runs. -->
     <permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION"
-        android:permissionGroup="android.permission-group.NETWORK"
         android:label="@string/permlab_downloadWithoutNotification"
         android:description="@string/permdesc_downloadWithoutNotification"
         android:protectionLevel="normal"/>


### PR DESCRIPTION
With the commit below, a lot of permission groups were removed but the ones
in repos like this were left behind. Leaving them here throws a warning and
just looks lazy.

https://github.com/DirtyUnicorns/android_frameworks_base/commit/61a4dd5c6677048fcbcbdf2de402649dba50bbeb

Change-Id: I4c64c1f8651c09a0e472bafbee4b5dd0cf418648